### PR TITLE
Adding preview header

### DIFF
--- a/_extensions/posit-docs/theme.scss
+++ b/_extensions/posit-docs/theme.scss
@@ -18,6 +18,11 @@ $posit-burgundy-1:#78384F;
 $posit-burgundy-2:#542938;
 
 $primary: $posit-blue;
+
+// Feature preview heading colors
+$preview-header: #EE6331; /* posit orange, contrast: 8.45 */
+$preview-header-border: darken($preview-header, 5%);
+
 // scss-docs-end color-variables
 
 // Typography
@@ -128,4 +133,35 @@ $list-group-color: $primary !default;
 /* List disc colors */
 li::marker {
     color: $primary;
+}
+
+/* the feature PREVIEW header */
+.preview-header > h1:after,
+.preview-header > h2:after,
+.preview-header > h3:after,
+.preview-header > h4:after,
+header h1 .preview-header {
+  content: "Preview feature";
+  margin-left: 1em;
+  position: relative;
+  border-radius: 50rem !important;
+  top: -0.5em;
+}
+
+.preview-header > h1:after,
+.preview-header > h2:after,
+.preview-header > h3:after,
+.preview-header > h4:after,
+header h1 .preview-header,
+div span.preview-feature {
+  color: $preview-header;
+  border: 1px solid $preview-header-border;
+  font-weight: 400;
+  font-size: 9pt !important;
+  padding: 0rem 0.4rem;
+}
+
+div span.preview-feature {
+  margin-left: 1em;
+  text-transform: uppercase;
 }

--- a/index.qmd
+++ b/index.qmd
@@ -8,7 +8,7 @@ format:
 
 ### Level Three
 
-### Another Level Three
+### Another Level Three {.preview-header} 
 
 ## Level Two Again
 


### PR DESCRIPTION
As @melissa-barca suggested in issue #12 - it would be good to have the Preview header style baked into the theme so other products could implement it, if needed, and remain consistent.

Resolves issue #12 

<img width="1129" alt="2024-03-22_10-58-03" src="https://github.com/posit-dev/product-doc-theme/assets/31460023/bcef891a-6177-4c42-bbda-e33359f92cf6">
