### PR TITLE
Footer text/image needs "full path" to use .svg or images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,30 @@ format:
 
 ### Additional configuration entries
 
-The following entries are unique to each product.
+The following entries may be unique to each product. Please review the following and make manual updates to your project, as required.
+
+#### Nav bar
+
+If you have existing `navbar: right` entries in your project's `_quarto.yml`:
+
+```
+navbar:
+   right:
+```
+
+Then, copy/paste the following into your project's `_quarto.yml` and then comment out these entries in the `posit-docs/_extension.yml`:
+
+```
+right:
+  - icon: "list"
+    menu:
+      - text: "docs.posit.co"
+        href: "https://docs.posit.co"
+      - text: "Posit Support"
+        href: "https://support.posit.co/hc/en-us/"
+```
+
+#### Footer
 
 - Copyright: Since the product copyright dates should be represented as a range and is dependent on the product, override the entry in your project's `quarto.yml` file.
 - Posit Product version: Since some products choose to autmate this entry with a version variable, it should be added/configured in your project's `quarto.yml` file.
@@ -38,4 +61,4 @@ page-footer:
           <Posit Product version - replace in project> 
 ```
 
-By copy/pasting and editing these entries into your project's yml, those entries will override 1:1 entries in the `_extension.yml`.
+By copy/pasting and editing these entries into your project's yml, those entries will overwrite 1:1 entries in the `_extension.yml`.

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -38,6 +38,8 @@ contributes:
             href: https://support.posit.co/hc/en-us
           - icon: lightbulb-fill
             href: https://solutions.posit.co
+          - text: "<img src='_extensions/posit-docs/assets/images/posit-logo-black-TM.svg' id='navbar-right-logo'>"
+            url: "https://posit.co"
   formats:
     html:
       theme: [theme.scss]

--- a/_extensions/posit-docs/theme.scss
+++ b/_extensions/posit-docs/theme.scss
@@ -80,6 +80,12 @@ $list-group-color: $primary !default;
     font-weight: 500;
 }
 
+/* Posit logo - navbar or footer */
+#navbar-right-logo {
+  width: 70px;
+  min-width: 70px;
+}
+
 .nav-link {
     font-family: $font-family-monospace;
     text-transform: uppercase;
@@ -173,21 +179,21 @@ ol.groovyAlpha {
     counter-reset: list-counter;
   }
   
-  ol.groovyAlpha li {
-    counter-increment: list-counter;
-  }
-  
-  ol.groovyAlpha li > p:before {
-    content: counter(list-counter, lower-alpha);
-    width: 16px;
-    height: 16px;
-    text-align: center;
-    margin-right: 10px;
-    color: #fff;
-    background-color: #fc403b;
-    display: inline-block;
-    border-radius: 8px;
-    font-size: 9px;
-    line-height: 16px;
-    vertical-align: middle;
-  }
+ol.groovyAlpha li {
+  counter-increment: list-counter;
+}
+
+ol.groovyAlpha li > p:before {
+  content: counter(list-counter, lower-alpha);
+  width: 16px;
+  height: 16px;
+  text-align: center;
+  margin-right: 10px;
+  color: #fff;
+  background-color: #fc403b;
+  display: inline-block;
+  border-radius: 8px;
+  font-size: 9px;
+  line-height: 16px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
If I add
```
 - text: "<img src='assets/images/posit-logo-black-TM.svg' id='navbar-right-logo'>"
```
the image is broken and 404s. 

However, that is the same path used for other img/svg entries throughout the yml. 

Using 
```
- text: "<img src='_extensions/posit-docs/assets/images/posit-logo-black-TM.svg' id='navbar-right-logo'>"
```
Works...

