### PR TITLE
Icon/image in footer 404ing in project (Update _extension.yml to icon footer path)

### DIFF
--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -36,9 +36,9 @@ contributes:
             href: https://support.posit.co/hc/en-us
           - icon: lightbulb-fill
             href: https://solutions.posit.co
-          - text: "<img src='_extensions/posit-docs/assets/images/posit-guide-ltmd.svg' id='footer-right-logo'>"
+          - text: "<img src='_extensions/posit-dev/posit-docs/assets/images/posit-guide-ltmd.svg' id='footer-right-logo'>"
             href: https://docs.posit.co
-          - text: "<img src='_extensions/posit-docs/assets/images/posit-logo-black-TM.svg' id='footer-right-posit-logo'>"
+          - text: "<img src='_extensions/posit-dev/posit-docs/assets/images/posit-logo-black-TM.svg' id='footer-right-posit-logo'>"
             url: "https://posit.co"
   formats:
     html:


### PR DESCRIPTION
The icon paths for the footers don't seem to work once installed in a project until the entire path is added

Resolves #16 