### PR TITLE
Adding nav back to extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,14 @@ format:
 > If you use `format: html` to perform any modifications to pages or
 > directories, rewrite those settings in terms of `format: posit-docs-html`.
 
-
 ### Additional configuration entries
 
 The following entries may be unique to each product. Please review the following and make manual updates to your project, as required.
 
 #### Navbar
 
-Use the following `website.navbar.right` entries in your `_quarto.yml`,
-merging with other entries if you have them:
+If you have `website.navbar.right` entries in your `_quarto.yml`,
+merge the following with the existing entries:
 
 ```
 website:

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -1,6 +1,6 @@
 title: posit-docs
 author: Ashley Henry, David Aja
-version: 1.0.1
+version: 1.0.2
 quarto-requred: ">=1.3.340"
 contributes:
   project:

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -14,6 +14,13 @@ contributes:
         pinned: true
         logo: "assets/images/posit-icon-fullcolor.svg"
         logo-alt: "Posit Documentation"  
+        right:
+         - icon: "list"
+           menu:
+           - text: "docs.posit.co"
+             href: "https://docs.posit.co"
+           - text: "Posit Support"
+             href: "https://support.posit.co/hc/en-us/"
       sidebar:
         style: "floating"
         collapse-level: 1

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,14 +3,6 @@ project:
   type: posit-docs
   
 website:
-  navbar:
-    right:
-      - icon: "list"
-        menu:
-          - text: "docs.posit.co"
-            href: "https://docs.posit.co"
-          - text: "Posit Support"
-            href: "https://support.posit.co/hc/en-us/"
   page-footer:
     left: |
       Copyright &copy; 2000-{{< env CURRENT_YEAR >}} Posit Software, PBC. All Rights Reserved.


### PR DESCRIPTION
Since workbench is currently the only team that will need to make manual adjustments, I think that this should stay in the theme by default.
The entire point is to have it standard and customizable IF the team needs to make adjustments based on their unique needs. 