### PR TITLE
expanded example and some adjustments from connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,30 @@ Make the following modifications:
     GitHub](https://github.com/posit-dev/product-doc-theme/tree/main/_extensions/posit-docs/assets/images).
 
 By copy/pasting and editing these entries into your project's yml, those entries will overwrite 1:1 entries in the `_extension.yml`.
+
+
+## Development
+
+If you are modifying this extension, use Quarto to preview your changes
+against the sample project defined here.
+
+```bash
+quarto preview
+```
+
+### Release
+
+To release a new version of this theme:
+
+1.  Make sure that the extension declares the target version. Update
+    [`_extensions/posit-docs/_extension.yml`](https://github.com/posit-dev/product-doc-theme/blob/main/_extensions/posit-docs/_extension.yml),
+    then commit and merge that change to `main`.
+
+2.  Tag the target commit and push the tag.
+
+    ```bash
+    git tag -a v1.1.0 -m 'Release 1.1.0'
+    git push origin v1.1.0
+    ```
+
+3.  Create a GitHub release from [that tag](https://github.com/posit-dev/product-doc-theme/tags).

--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ Make the following modifications:
 
 By copy/pasting and editing these entries into your project's yml, those entries will overwrite 1:1 entries in the `_extension.yml`.
 
+#### Analytics
+
+Configure Google Analytics using a snippet like the following.
+
+```yaml
+format:
+  posit-docs-html:
+    include-in-header: _analytics.html
+```
+
+This uses the [`_analytics.html`](_analytics.html) and
+[`_variables.yml`](_variables.yml) files in the example project. For Posit
+product documentation hosted on <https://docs.posit.co/>, copy these files
+into your project.
 
 ## Development
 

--- a/_analytics.html
+++ b/_analytics.html
@@ -1,0 +1,40 @@
+<!-- Google Analytics 4 (G-XXXXXXXXXX) -->
+<script>
+ /* Use GA when hosted by our public docs site, not when installed. */
+ if (location.href.indexOf("docs.posit.co") >= 0) {
+     window.dataLayer = window.dataLayer || []
+     function gtag() { dataLayer.push(arguments) }
+     /* Set up integration and send page view */
+     gtag("js", new Date())
+     gtag("config", "{{< var analytics.google >}}")
+
+     /* Register virtual event handlers */
+     document.addEventListener("DOMContentLoaded", function () {
+         if (document.forms.search) {
+             var query = document.forms.search.query
+             query.addEventListener("blur", function () {
+                 if (this.value) {
+                     gtag("event", "search", { search_term: this.value })
+                 }
+             })
+         }
+
+         /* Send page view on location change */
+         if (typeof location$ !== "undefined")
+             location$.subscribe(function (url) {
+                 gtag("config", "{{< var analytics.google >}}", {
+                     page_path: url.pathname
+                 })
+             })
+     })
+     /* Create script tag */
+     var script = document.createElement("script")
+     script.async = true
+     script.src = "https://www.googletagmanager.com/gtag/js?id={{< var analytics.google >}}"
+
+     /* Inject script tag */
+     var container = document.getElementsByTagName("head")[0]
+     var firstChild = container.firstChild
+     container.insertBefore(script, firstChild)
+ }
+</script>

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -20,13 +20,10 @@ contributes:
              href: "https://docs.posit.co"
            - text: "Posit Support"
              href: "https://support.posit.co/hc/en-us/"
-      sidebar:
-        style: "floating"
-        collapse-level: 1
-        pinned: false
       search:
         copy-button: true
         show-item-context: true
+    format: posit-docs-html
   formats:
     html:
       theme: [theme.scss]

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -7,7 +7,6 @@ contributes:
     project:
       type: website
     website:
-      title: 
       favicon: "assets/images/favicon.svg"
       bread-crumbs: true
       navbar:
@@ -24,8 +23,10 @@ contributes:
       sidebar:
         style: "floating"
         collapse-level: 1
-        search: true
         pinned: false
+      search:
+        copy-button: true
+        show-item-context: true
   formats:
     html:
       theme: [theme.scss]

--- a/_extensions/posit-docs/theme.scss
+++ b/_extensions/posit-docs/theme.scss
@@ -80,6 +80,13 @@ $list-group-color: $primary !default;
     font-weight: 500;
 }
 
+/* Style for the version included in the website title */
+.navbar-title small {
+    font-size: 0.6em;
+    display: block;
+    padding-left: 1em;
+}
+
 /* Posit logo - navbar or footer */
 #footer-right-posit-logo {
   width: 70px;

--- a/_extensions/posit-docs/theme.scss
+++ b/_extensions/posit-docs/theme.scss
@@ -82,7 +82,7 @@ $list-group-color: $primary !default;
 
 /* Style for the version included in the website title */
 .navbar-title small {
-    font-size: 0.6em;
+    font-size: 14px;
     display: block;
     padding-left: 1em;
 }

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,8 +1,30 @@
 project:
-  title: "Posit Documentation"
   type: posit-docs
   
 website:
+  title: 'Posit Product Documentation <small>Version {{< env PRODUCT_VERSION >}}</small>'
+  navbar:
+    left:
+      - text: "Home"
+        href: "index.qmd"
+      - text: "Admin Guide"
+        file: "admin.qmd"
+      - text: "User Guide"
+        file: "user.qmd"
+
+  sidebar:
+    - id: admin-guide
+      title: "Admin Guide"
+      contents:
+        - admin.qmd
+        - install.qmd
+
+    - id: user-guide
+      title: "User Guide"
+      contents:
+        - user.qmd
+        - sharing.qmd
+
   page-footer:
     left: |
       Copyright &copy; 2000-{{< env CURRENT_YEAR >}} Posit Software, PBC. All Rights Reserved.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,24 +6,34 @@ website:
   navbar:
     left:
       - text: "Home"
-        href: "index.qmd"
+        href: index.qmd
       - text: "Admin Guide"
-        file: "admin.qmd"
+        file: admin.qmd
       - text: "User Guide"
-        file: "user.qmd"
+        file: user.qmd
 
+  # Hybrid navigation meant to show some amount of nested sidebar navigation
+  # https://quarto.org/docs/websites/website-navigation.html#hybrid-navigation
   sidebar:
-    - id: admin-guide
-      title: "Admin Guide"
+    - title: "Admin Guide"
       contents:
         - admin.qmd
-        - install.qmd
+        - section: Subsection
+          contents:
+            - text: Installation
+              file: install.qmd
+            - text: Duplicate
+              file: install.qmd
 
-    - id: user-guide
-      title: "User Guide"
+    - title: "User Guide"
       contents:
         - user.qmd
-        - sharing.qmd
+        - section: Subsection
+          contents:
+            - text: Sharing
+              file: sharing.qmd
+            - text: Duplicate
+              file: sharing.qmd
 
   page-footer:
     left: |
@@ -39,7 +49,3 @@ website:
         href: "https://docs.posit.co/"
       - text: "<img src='/_extensions/posit-docs/assets/images/posit-logo-black-TM.svg' id='footer-right-posit-logo'>"
         href: "https://posit.co/"
-
-format:
-  posit-docs-html:
-    toc: true

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,0 +1,2 @@
+analytics:
+  google: "GTM-KHBDBW7"

--- a/admin.qmd
+++ b/admin.qmd
@@ -6,6 +6,9 @@ subtitle: Version {{< env PRODUCT_VERSION >}}
 This is a stub page modeling a top-level collection of documentation, such as
 a product admin guide.
 
+This page should have a left-hand sidebar with repetitive links to the
+[Installation](install.qmd) page.
+
 ## More
 
 You may learn more.

--- a/admin.qmd
+++ b/admin.qmd
@@ -1,0 +1,15 @@
+---
+title: Posit Product Admin Guide
+subtitle: Version {{< env PRODUCT_VERSION >}}
+---
+
+This is a stub page modeling a top-level collection of documentation, such as
+a product admin guide.
+
+## More
+
+You may learn more.
+
+### Problems
+
+You may not learn more.

--- a/index.qmd
+++ b/index.qmd
@@ -33,3 +33,48 @@ $ zypper
 ```
 
 :::
+
+## Level two: callouts
+
+Code-first means using code first. Does that mean we never do things manually?
+No. Hands-on is delightful.
+
+::: {.callout-note}
+This is a note.
+:::
+
+::: {.callout-warning}
+This is a warning.
+:::
+
+::: {.callout-important}
+This is important.
+:::
+
+::: {.callout-tip}
+This is a tip.
+:::
+
+::: {.callout-caution}
+This is a cautionary tale.
+:::
+
+::: {.callout-note collapse="true"}
+This is a collapsed note.
+:::
+
+::: {.callout-note}
+## Some notes are not
+
+This is a note with an alternate title.
+:::
+
+## Level two: coding
+
+```r
+cat("cats are cats\n")
+```
+
+```python
+print("snakes are not cats")
+```

--- a/install.qmd
+++ b/install.qmd
@@ -1,0 +1,5 @@
+---
+title: Installation
+---
+
+This is a stub page modeling a sub-page within the admin guide.

--- a/sharing.qmd
+++ b/sharing.qmd
@@ -1,0 +1,5 @@
+---
+title: Sharing
+---
+
+This is a stub page modeling a sub-page within the user guide.

--- a/user.qmd
+++ b/user.qmd
@@ -1,0 +1,7 @@
+---
+title: Posit Product User Guide
+subtitle: Version {{< env PRODUCT_VERSION >}}
+---
+
+This is a stub page modeling a top-level collection of documentation, such as
+a product user guide.


### PR DESCRIPTION
1. improve the README.
2. Improve the example site to have hybrid sidebar navigation.
3. remove `webside.sidebar` navigation from the extension, since that prevented hybrid sidebar navigation. other than `collapse-level` and `search`, this only provided default values.
4. add `format: posit-docs-html` to the extension, following the example at https://quarto.org/docs/extensions/project-types.html
5. add "small" styling for the product version in the navbar.
6. enable search copy-button and search show-item-content.

Projects will need to explicitly configure `sidebar.collapse-level` and `sidebar.search` if they need it.