### PR TITLE
Update _extension.yml - remove toc expand true

### DIFF
--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -29,4 +29,3 @@ contributes:
         link-external-icon: true
         link-external-newwindow: true
         toc: true
-        toc-expand: true


### PR DESCRIPTION
I missed this during the review. We don't want this as a default. If a team wants to expand their TOC by default, they are welcome to but this created a bit of a disaster for Workbench and we can't seem to "fix" or override this by adding it to the quartl.yml OR removing it manually from the extension file. We can add back later after testing