### PR TITLE
automatic analytics configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,21 +86,6 @@ Make the following modifications:
 
 By copy/pasting and editing these entries into your project's yml, those entries will overwrite 1:1 entries in the `_extension.yml`.
 
-#### Analytics
-
-Configure Google Analytics using a snippet like the following.
-
-```yaml
-format:
-  html:
-    include-in-header: _analytics.html
-```
-
-This uses the [`_analytics.html`](_analytics.html) and
-[`_variables.yml`](_variables.yml) files in the example project. For Posit
-product documentation hosted on <https://docs.posit.co/>, copy these files
-into your project.
-
 ## Development
 
 If you are modifying this extension, use Quarto to preview your changes

--- a/README.md
+++ b/README.md
@@ -99,9 +99,13 @@ quarto preview
 
 To release a new version of this theme:
 
-1.  Make sure that the extension declares the target version. Update
-    [`_extensions/posit-docs/_extension.yml`](https://github.com/posit-dev/product-doc-theme/blob/main/_extensions/posit-docs/_extension.yml),
-    then commit and merge that change to `main`.
+1.  Make sure that the extension declares the target version and documents its
+    changes.
+
+    1.  Update [`_extensions/posit-docs/_extension.yml`](https://github.com/posit-dev/product-doc-theme/blob/main/_extensions/posit-docs/_extension.yml)
+    1.  Update [`changelog.md`](https://github.com/posit-dev/product-doc-theme/blob/main/changelog.md)
+
+    Commit and merge both changes to `main`.
 
 2.  Tag the target commit and push the tag.
 

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -1,7 +1,7 @@
 title: posit-docs
 author: Ashley Henry, David Aja, Aron Atkins
-version: 2.0.1
-quarto-requred: ">=1.3.340"
+version: 3.0.0
+quarto-required: ">=1.3.340"
 contributes:
   project:
     project:

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -30,3 +30,4 @@ contributes:
         link-external-newwindow: true
         toc: true
         toc-expand: true
+        include-in-header: "assets/_analytics.html"

--- a/_extensions/posit-docs/assets/_analytics.html
+++ b/_extensions/posit-docs/assets/_analytics.html
@@ -6,7 +6,7 @@
      function gtag() { dataLayer.push(arguments) }
      /* Set up integration and send page view */
      gtag("js", new Date())
-     gtag("config", "{{< var analytics.google >}}")
+     gtag("config", "GTM-KHBDBW7")
 
      /* Register virtual event handlers */
      document.addEventListener("DOMContentLoaded", function () {
@@ -22,7 +22,7 @@
          /* Send page view on location change */
          if (typeof location$ !== "undefined")
              location$.subscribe(function (url) {
-                 gtag("config", "{{< var analytics.google >}}", {
+                 gtag("config", "GTM-KHBDBW7", {
                      page_path: url.pathname
                  })
              })
@@ -30,7 +30,7 @@
      /* Create script tag */
      var script = document.createElement("script")
      script.async = true
-     script.src = "https://www.googletagmanager.com/gtag/js?id={{< var analytics.google >}}"
+     script.src = "https://www.googletagmanager.com/gtag/js?id=GTM-KHBDBW7"
 
      /* Inject script tag */
      var container = document.getElementsByTagName("head")[0]

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,8 @@
 project:
   type: posit-docs
+  render:
+    - "*.qmd"
+    - "!changelog.md"
   
 website:
   title: 'Posit Product Documentation <small>Version {{< env PRODUCT_VERSION >}}</small>'

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,2 +1,0 @@
-analytics:
-  google: "GTM-KHBDBW7"

--- a/changlog.md
+++ b/changlog.md
@@ -1,7 +1,7 @@
-# unreleased
+# v3.0.0
 
-* Automatically configure analytics. Projects no longer need a copy of
-  `_analytics.html` or the `analytics.google` entry in `_variables.yml`.
+* (Breaking) Automatically configure analytics. Projects no longer need a copy
+  of `_analytics.html` or the `analytics.google` entry in `_variables.yml`.
 
 # v2.0.1
 
@@ -11,8 +11,8 @@
 
 # v2.0.0
 
-* Remove `posit-docs-html` and have the `posit-docs` project type directly
-  modify the `html` format.
+* (Breaking) Remove `posit-docs-html` and have the `posit-docs` project type
+  directly modify the `html` format.
 
 # v1.2.0
 

--- a/changlog.md
+++ b/changlog.md
@@ -1,0 +1,33 @@
+# unreleased
+
+* Automatically configure analytics. Projects no longer need a copy of
+  `_analytics.html` or the `analytics.google` entry in `_variables.yml`.
+
+# v2.0.1
+
+* Adjust body letter spacing.
+* Adjust sidebar and TOC style.
+* Adjust list style.
+
+# v2.0.0
+
+* Remove `posit-docs-html` and have the `posit-docs` project type directly
+  modify the `html` format.
+
+# v1.2.0
+
+* Expanded example site to demonstrate multiple pages, callouts, sidebar, and analytics.
+* Remove `website.sidebar` from the extension.
+* Configure search copy button and item context.
+* Specify `posit-docs-html` as the default theme when using the `project.type: posit-docs`.
+* Style `<small>` in the navbar; used for product version.
+
+# v1.1.0
+
+* Update instructions and theme inclusions.
+* Footer must be configured when used.
+* Navbar should be inherited.
+
+# v1.0.0
+
+Initial release.

--- a/changlog.md
+++ b/changlog.md
@@ -1,4 +1,4 @@
-# v3.0.0
+# v3.0.0 (unreleased)
 
 * (Breaking) Automatically configure analytics. Projects no longer need a copy
   of `_analytics.html` or the `analytics.google` entry in `_variables.yml`.


### PR DESCRIPTION
The `include-in-header: "assets/_analytics.html"` is automatically resolved to a path within the extension, meaning that projects do not need copies of the analytics snippet and variable.

fixes #48