### PR TITLE
Indentation fix for `_extension.yml`

### DIFF
--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -14,19 +14,19 @@ contributes:
         logo: "assets/images/posit-icon-fullcolor.svg"
         logo-alt: "Posit Documentation"
         right:
-         - icon: "list"
-           aria-label: 'Drop-down menu for additional Posit resources'
-           menu:
-           - text: "docs.posit.co"
-             href: "https://docs.posit.co"
-           - text: "Posit Support"
-             href: "https://support.posit.co/hc/en-us/"
+          - icon: "list"
+            aria-label: 'Drop-down menu for additional Posit resources'
+            menu:
+              - text: "docs.posit.co"
+                href: "https://docs.posit.co"
+              - text: "Posit Support"
+                href: "https://support.posit.co/hc/en-us/"
       search:
         copy-button: true
         show-item-context: true
     format:
       html:
-        theme: 
+        theme:
           light: [theme.scss]
           dark: [theme-dark.scss]
         link-external-icon: true


### PR DESCRIPTION
Automated formatting for YAML wasn't happy with how this file was before.