### PR TITLE
Adding Cookie Consent to theme by default

### DIFF
--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -36,5 +36,4 @@ contributes:
         link-external-newwindow: true
         toc: true
         toc-expand: true
-    # NEW SITES ONLY - DO NOT USE GOOGLE ANALYTICS - WE NEED TO ADD COOKIE CONSENT TO THEME. EXISTING SITES - YOU CAN ENABLE THE _ANALYTICS.HTML FILE BELOW TO CONTINUE USING GA
         include-in-header: "assets/_analytics.html"

--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -8,6 +8,9 @@ contributes:
       type: website
     website:
       favicon: "assets/images/favicon.svg"
+      cookie-consent:
+        type: express
+        style: headline
       bread-crumbs: true
       navbar:
         pinned: true
@@ -34,4 +37,4 @@ contributes:
         toc: true
         toc-expand: true
     # NEW SITES ONLY - DO NOT USE GOOGLE ANALYTICS - WE NEED TO ADD COOKIE CONSENT TO THEME. EXISTING SITES - YOU CAN ENABLE THE _ANALYTICS.HTML FILE BELOW TO CONTINUE USING GA
-       # include-in-header: "assets/_analytics.html"
+        include-in-header: "assets/_analytics.html"

--- a/_extensions/posit-docs/assets/_analytics.html
+++ b/_extensions/posit-docs/assets/_analytics.html
@@ -1,5 +1,5 @@
 <!-- Google Analytics 4 (G-XXXXXXXXXX) -->
-<script>
+<script type="text/plain" cookie-consent="tracking">
  /* Use GA when hosted by our public docs site, not when installed. */
  if (location.href.indexOf("docs.posit.co") >= 0) {
      window.dataLayer = window.dataLayer || []


### PR DESCRIPTION
## What:

New sites cannot have google analytics or tracking unless we add cookie consent.
Quarto has cookie consent functionality.

I've added the functionality to the theme so it will be there by default. 

We are waiting on approval from Rick - once that happens, I will merge this in.

Closes #81 

On hold/blocked by: https://github.com/rstudio/docs.rstudio.com/pull/1934


### Testing steps

**PRs will not be approved if testing notes aren't included here.**

- Build quarto docs
- Google Inspect > Application tab > deleted all cookies
- Added cookie consent
- Rebuilt/previewed the docs
- Cookie banner displays and also checked the Application tab to confirm that cookies are not present until I agree/opt in

<img width="942" alt="2024-12-11_12-26-07" src="https://github.com/user-attachments/assets/501114b7-8298-4d06-8590-9c196079af08" />

