### PR TITLE
Conditional GA handling

### DIFF
--- a/_extensions/posit-docs/_extension.yml
+++ b/_extensions/posit-docs/_extension.yml
@@ -9,10 +9,6 @@ contributes:
     website:
       favicon: "assets/images/favicon.svg"
       bread-crumbs: true
-      cookie-consent:
-        type: express
-        style: interstitial
-        policy-url: https://posit.co/privacy
       navbar:
         pinned: true
         logo: "assets/images/posit-icon-fullcolor.svg"
@@ -38,4 +34,3 @@ contributes:
         toc: true
         toc-expand: true
         include-in-header: "assets/_analytics.html"
-        include-before-body: "assets/_analytics-body.html"

--- a/_extensions/posit-docs/assets/_analytics-body.html
+++ b/_extensions/posit-docs/assets/_analytics-body.html
@@ -1,4 +1,0 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KHBDBW7"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->

--- a/_extensions/posit-docs/assets/_analytics.html
+++ b/_extensions/posit-docs/assets/_analytics.html
@@ -1,3 +1,29 @@
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KHBDBW7');</script>
- <!-- End Google Tag Manager -->
+<script type="text/javascript">
+    if (sURL.includes("docs.posit.co") || sURL.includes("netlify.app")) {
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KHBDBW7');
+    }
+</script>
+<!-- End Google Tag Manager -->
+
+<!-- Display cookie icon in footer in docs.posit.co/netlify.app URLs; hide icon on other URLs -->
+<script type="text/javascript">
+window.onload = function () {
+    let prefCenter = document.querySelector("#open_preferences_center");
+    let sURL = window.location.href;
+
+    if (prefCenter) { // Test for prefCenter ID presence
+        // Show the icon only if the URL contains "docs.posit.co" or "netlify.app"
+        if (sURL.includes("docs.posit.co") || sURL.includes("netlify.app")) {
+            prefCenter.style.display = "inline";
+            prefCenter.style.visibility = "visible";
+        } else {
+            // Hide the icon for all other URLs
+            prefCenter.style.display = "none";
+            prefCenter.style.visibility = "hidden";
+        }
+    }
+};
+</script>
+<!-- End display/hide cookie icon -->
+ 

--- a/_extensions/posit-docs/assets/_analytics.html
+++ b/_extensions/posit-docs/assets/_analytics.html
@@ -1,5 +1,6 @@
 <!-- Google Tag Manager -->
 <script type="text/javascript">
+    const sURL = window.location.href;
     if (sURL.includes("docs.posit.co") || sURL.includes("netlify.app")) {
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KHBDBW7');
     }
@@ -9,8 +10,8 @@
 <!-- Display cookie icon in footer in docs.posit.co/netlify.app URLs; hide icon on other URLs -->
 <script type="text/javascript">
 window.onload = function () {
-    let prefCenter = document.querySelector("#open_preferences_center");
-    let sURL = window.location.href;
+    const prefCenter = document.querySelector("#open_preferences_center");
+    const sURL = window.location.href;
 
     if (prefCenter) { // Test for prefCenter ID presence
         // Show the icon only if the URL contains "docs.posit.co" or "netlify.app"
@@ -26,4 +27,3 @@ window.onload = function () {
 };
 </script>
 <!-- End display/hide cookie icon -->
- 


### PR DESCRIPTION
Resolves #97 

This PR: 
1. adds the snippet that Andrew sent over (with a small tweak in the GTM section to define `sURL` before using it + `const` instead of `let` as we are not redefining anything),
2. updates the extension to remove anything about cookie consent, since GTM will now be managing that, and
3. removes the `_analytics-body.html` as I believe it is no longer relevant.

Locally, I tested: 
- [X] manually adding localhost to the check(s) to see that GTM would get loaded (it does) and that the cookie icon appears in the footer (it does)
- [X] removing the cookie icon from the footer in the test site to ensure no exceptions were thrown (there weren't)

I think that covers what we can verify here, but please let me know if I missed anything.