### PR TITLE
fix: tweak selector logic to hide cookie icon in a more accessible way

### DIFF
--- a/_extensions/posit-docs/assets/_analytics.html
+++ b/_extensions/posit-docs/assets/_analytics.html
@@ -10,10 +10,9 @@
 <!-- Display cookie icon in footer in docs.posit.co/netlify.app URLs; hide icon on other URLs -->
 <script type="text/javascript">
 window.onload = function () {
-    const prefCenter = document.querySelector("#open_preferences_center");
-    const sURL = window.location.href;
-
+    const prefCenter = document.querySelector("li:has(#open_preferences_center)");
     if (prefCenter) { // Test for prefCenter ID presence
+        const sURL = window.location.href;
         // Show the icon only if the URL contains "docs.posit.co" or "netlify.app"
         if (sURL.includes("docs.posit.co") || sURL.includes("netlify.app")) {
             prefCenter.style.display = "inline";

--- a/_extensions/posit-docs/assets/_analytics.html
+++ b/_extensions/posit-docs/assets/_analytics.html
@@ -10,6 +10,8 @@
 <!-- Display cookie icon in footer in docs.posit.co/netlify.app URLs; hide icon on other URLs -->
 <script type="text/javascript">
 window.onload = function () {
+    // target the <li> instead of the icon to allow screenreaders to properly
+    // calculate the size of the list when the icon is hidden
     const prefCenter = document.querySelector("li:has(#open_preferences_center)");
     if (prefCenter) { // Test for prefCenter ID presence
         const sURL = window.location.href;


### PR DESCRIPTION
## Description
This PR tweaks the JS we're using to hide the cookie icon when docs are hosted on domains where we don't include GTM, and hides the containing `<li>` instead of its children. This allows a screenreader to properly calculate the length of the list of items in the footer.

Fixes #102 

## Verification

- [X] Brought up VoiceOver (cmd + fn + F5) and then the rotor (ctrl + option + u) to navigate to the footer, then moved to the list containing the items (ctrl + option + right arrow until it's selected). Confirmed that when the cookie icon is hidden, the length of the list announced is accurate
- [X] Brought up VoiceOver (cmd + fn + F5) and then the rotor (ctrl + option + u) to navigate to the footer, then moved to the list containing the items (ctrl + option + right arrow until it's selected). Confirmed that when the cookie icon is visible, the length of the list announced is also accurate.